### PR TITLE
Fix code scanning alert no. 9: Uncontrolled data used in path expression

### DIFF
--- a/test-storybooks/server-kitchen-sink/server.js
+++ b/test-storybooks/server-kitchen-sink/server.js
@@ -16,7 +16,13 @@ app.set('view engine', 'pug');
 app.get('/', (req, res) => res.send('Hello World!'));
 
 app.get(/storybook_preview\/(.*)/, (req, res) => {
-  res.render(req.params[0], req.query);
+  const safeRoot = path.join(__dirname, 'views');
+  let requestedPath = path.resolve(safeRoot, req.params[0]);
+  if (!requestedPath.startsWith(safeRoot)) {
+    res.status(403).send('Forbidden');
+    return;
+  }
+  res.render(requestedPath, req.query);
 });
 
 app.listen(port, () => logger.info(`Server listening on port ${port}!`));


### PR DESCRIPTION
Fixes [https://github.com/automatik-engineering/silver-meme/security/code-scanning/9](https://github.com/automatik-engineering/silver-meme/security/code-scanning/9)

To fix the problem, we need to ensure that the path derived from `req.params[0]` is validated and sanitized before being used in the `res.render` function. We can achieve this by:
1. Normalizing the path using `path.resolve` to remove any ".." segments.
2. Ensuring that the resolved path is within a predefined safe directory.

This approach will prevent path traversal attacks and ensure that only valid paths within the allowed directory are used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
